### PR TITLE
Enforce player move and suggestion rules

### DIFF
--- a/cluegonauts/clueless/classes.py
+++ b/cluegonauts/clueless/classes.py
@@ -32,6 +32,7 @@ class Character:
     user_id: Optional[str] = None
     cards: List[Card] = []
     location: Location = None
+    moved_by_suggestion: bool = False
 
 class CharacterHandler:
     def __init__(self, selected: List[str] = []):
@@ -126,15 +127,15 @@ class LocationHandler:
                 Location(location_id="study", name="Study", connected_location=["hallway_1", "hallway_3"], has_secret_passage=True, secret_passage_to="kitchen", image= "study_gv.png"), 
                 Location(location_id="hallway_1", name="Hallway 1", connected_location=["study", "hall"], image= "hallway_vertical_gv.png"), 
                 Location(location_id="hall", name="Hall", connected_location=["hallway_2", "hallway_4", "hallway_1"], image="hall_gv.png"), 
-                Location(location_id="hallway_2", name="Hallway 2", connected_location=["hall", "lounge"], image= "hallway_vertical_gv.png"), 
+                Location(location_id="hallway_2", name="Hallway 2", connected_location=["hall", "lounge"], image= "hallway_vertical_gv.png", is_occupied=True), 
                 Location(location_id="lounge", name="Lounge", connected_location=["hallway_5", "hallway_2"], has_secret_passage=True, secret_passage_to="conservatory", image="lounge_gv.png")
             ],
             [
-                Location(location_id="hallway_3", name="Hallway 3", connected_location=["study", "library"], image= "hallway_horizontal_gv.png"),
+                Location(location_id="hallway_3", name="Hallway 3", connected_location=["study", "library"], image= "hallway_horizontal_gv.png", is_occupied=True),
                 Location(location_id="blank_1", name="Blank 1", connected_location=["hallway_1", "hallway_6"]), 
                 Location(location_id="hallway_4", name="Hallway 4", connected_location=["hall", "billiard_room"], image= "hallway_horizontal_gv.png"), 
                 Location(location_id="blank_2", name="Blank 2", connected_location=["hallway_2", "hallway_7"]), 
-                Location(location_id="hallway_5", name="Hallway 5", connected_location=["lounge", "dining_room"], image= "hallway_horizontal_gv.png")
+                Location(location_id="hallway_5", name="Hallway 5", connected_location=["lounge", "dining_room"], image= "hallway_horizontal_gv.png", is_occupied=True)
             ],
             [
                 Location(location_id="library", name="Library", connected_location=["hallway_3", "hallway_6", "hallway_8"], image= "library_gv.png"), 
@@ -144,7 +145,7 @@ class LocationHandler:
                 Location(location_id="dining_room", name="Dining Room", connected_location=["hallway_5", "hallway_10", "hallway_7"], image= "dining_room_gv.png")
             ],
             [ 
-                Location(location_id="hallway_8", name="Hallway 8", connected_location=["library", "conservatory"], image= "hallway_horizontal_gv.png"), 
+                Location(location_id="hallway_8", name="Hallway 8", connected_location=["library", "conservatory"], image= "hallway_horizontal_gv.png", is_occupied=True), 
                 Location(location_id="blank_3", name="Blank 3", connected_location=["hallway_6", "hallway_8"]), 
                 Location(location_id="hallway_9", name="Hallway 9", connected_location=["billiard_room", "ballroom"], image= "hallway_horizontal_gv.png"), 
                 Location(location_id="blank_4", name="Blank 4", connected_location=["hallway_7", "hallway_12"]), 
@@ -152,9 +153,9 @@ class LocationHandler:
             ],
             [
                 Location(location_id="conservatory", name="Conservatory", connected_location=["hallway_8", "hallway_11"], has_secret_passage=True, secret_passage_to="lounge", image="conservatory_gv.png"), 
-                Location(location_id="hallway_11", name="Hallway 11", connected_location=["conservatory", "ballroom"], image= "hallway_vertical_gv.png"), 
+                Location(location_id="hallway_11", name="Hallway 11", connected_location=["conservatory", "ballroom"], image= "hallway_vertical_gv.png", is_occupied=True), 
                 Location(location_id="ballroom", name="Ballroom", connected_location=["hallway_9", "hallway_12", "hallway_11"], image="ballroom_gv.png"), 
-                Location(location_id="hallway_12", name="Hallway 12", connected_location=["ballroom", "kitchen"], image= "hallway_vertical_gv.png"), 
+                Location(location_id="hallway_12", name="Hallway 12", connected_location=["ballroom", "kitchen"], image= "hallway_vertical_gv.png", is_occupied=True), 
                 Location(location_id="kitchen", name="Kitchen", connected_location=["hallway_10", "hallway_12"], has_secret_passage=True, secret_passage_to="study", image="kitchen_gv.png")
             ]
         ]

--- a/cluegonauts/clueless/templates/clueless/gameb.html
+++ b/cluegonauts/clueless/templates/clueless/gameb.html
@@ -8,8 +8,8 @@
   <div class="drawer drawer-end">
     <input id="detective-notebook" type="checkbox" class="drawer-toggle" />
     <div id="control-container" class="container mx-auto drawer-content">
-      <button class="btn btn-primary" onclick="player_suggestion.showModal()">Make a Suggestion</button>
-      <button id="accuse_button" class="btn btn-primary" onclick="player_accusation.showModal()">Make an Accusation</button>
+      <button id="suggest-button" class="btn btn-primary" disabled onclick="player_suggestion.showModal()">Make a Suggestion</button>
+      <button id="accuse_button" class="btn btn-primary" disabled  onclick="player_accusation.showModal()">Make an Accusation</button>
       <button class="btn btn-primary" onclick="card_carousel.showModal()">View Your Cards</button>
       <button onclick="toggleNotebook()" class="btn btn-primary">Toggle Detective Notebook</button>
       <button class="btn btn-primary" id="end-turn" class="btn btn-error" disabled>End Turn</button>
@@ -359,7 +359,8 @@
         } else if (data.message == "character_locations") {
 
             const charLocIcons = data.char_loc_icons;
-            
+
+            // for each char_id and location_id pair, add the character icon to the location, remove from previous location if different
             for (const [charID, charLocData] of Object.entries(charLocIcons)) {
                 const charLocation = charLocData[0];
                 const charIconPath = charLocData[1];
@@ -387,14 +388,8 @@
                     console.error('Element with ID ' + charLocation + ' not found.');
                 }
 
-                if (disabledLocations) {
-                    // re-enable all locations if player selects a valid move
-                    enableAllMoves();
-                }
                 
             };
-
-            // for each char_id and location_id pair, add the character icon to the location, remove from previous location if different
             
         } else if ("p2p" in data) {
             const senderID = data["char_id"];
@@ -471,11 +466,37 @@
             // Disable "Make Accusation" button
             const accusationButton = document.querySelector('#accuse_button');
             accusationButton.disabled = true;
+            accusationButton.classList.add('failed-accusation') // Add class to prevent enabling after failed accusation
         }
         if ("unlock_turn" in data) {
             // Enable "End Turn" button
             const endTurnButton = document.querySelector('#end-turn');
             endTurnButton.disabled = false;
+
+            // If player was moved by a suggestion, allow suggestions in current location
+            const wasLastMoveSuggested = data["last_move_suggest"];
+            if (wasLastMoveSuggested) {
+                const currentLoc = data["current_loc"];
+                const suggestionButton = document.querySelector('#suggest-button');
+                suggestionButton.disabled = false;
+                const suggestionForm = document.querySelector('#player_suggestion form');
+                const locationChocies = suggestionForm.location;
+                for (let i = 0; i < locationChocies.length; i++) {
+                    if (locationChocies[i].value !== currentLoc) {
+                        locationChocies[i].disabled = true;
+                    }
+            }
+            }
+
+            // Enable Accusation button if failed-accusation class is not present
+            const accusationButton = document.querySelector('#accuse_button');
+            if (!accusationButton.classList.contains('failed-accusation')) {
+                accusationButton.disabled = false;
+            }
+
+            // Enable moves if not already enabled
+            enableAllMoves();
+
         }
         if ("move_fail" in data) {
             disableInvalidMoves(data["valid_locations"]);
@@ -483,6 +504,25 @@
         if ("welcome_message" in data) {
             let characterLabel = document.getElementById("selected-character-name");
             characterLabel.innerText = data["char_name"];
+        }
+        if ("lock_move" in data) {
+            // Unlock suggestion button
+            const suggestionButton = document.querySelector('#suggest-button');
+            suggestionButton.disabled = false;
+
+            // Limit suggestion to moved location
+            const movedLocation = data["lock_move"];
+            // Set movedLocation as the only option for suggestion/ accusation
+            const suggestionForm = document.querySelector('#player_suggestion form');
+            const locationChocies = suggestionForm.location;
+            for (let i = 0; i < locationChocies.length; i++) {
+                if (locationChocies[i].value !== movedLocation) {
+                    locationChocies[i].disabled = true;
+                }
+            }
+            // Disable any additional moves, only one move is allowed per turn
+            // Will be re-enabled on unlock_turn
+            disableInvalidMoves([]);
         }
     };
 
@@ -503,6 +543,10 @@
         }));
         suggestionForm.reset();
         suggestionModal.close();
+
+        // Disable suggestion button
+        const suggestionButton = document.querySelector('#suggest-button');
+        suggestionButton.disabled = true;
     };
 
     // Handle disprove form suggestion


### PR DESCRIPTION
Resolves #34
Resolves #36 
- Disable suggestions and accusations until turn starts
- Disable suggestions until move unless player was last moved by a suggestion
- Make sure location.is_occupied is set correctly